### PR TITLE
Only set DEBIAN_FRONTEND during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM debian:sid
 MAINTAINER Patrick Double <pat@patdouble.com>
 
-ENV DEBIAN_FRONTEND noninteractive
 ENV LANG en_US.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
 RUN rm -rf /var/lib/apt/lists/* &&\
   apt-get -q update &&\
+  DEBIAN_FRONTEND=noninteractive &&\
   apt-get -qy --force-yes dist-upgrade &&\
   apt-get install -qy --force-yes ripit lame eyed3 imagemagick ffmpeg &&\
   apt-get clean &&\


### PR DESCRIPTION
Do not set it in the resulting image, which is discouraged because the container may
be run interactively at some point.
With this particular container, an interactive run is quite likely.

See https://github.com/docker/docker/issues/4032#issuecomment-34597177
